### PR TITLE
Dark Mode Focus Ring Override

### DIFF
--- a/SW_Virtual_CSS_vAMSYS_v5.css
+++ b/SW_Virtual_CSS_vAMSYS_v5.css
@@ -485,3 +485,12 @@ Author: Jan Podlipsky - jan.podlipsky@sw-virtual.eu
 	--tw-ring-color: rgba(var(--secondary-rgb), 0.8) !important;
 	border-color: rgba(var(--secondary-rgb), 0.8) !important;
 }
+
+.fi-input-wrp:focus-within {
+  --tw-ring-opacity: 1 !important;
+  --tw-ring-color: rgb(var(--secondary-rgb) / var(--tw-ring-opacity)) !important
+}
+.fi-input-wrp:focus-within:is(.dark *) {
+  --tw-ring-opacity: 1 !important;
+  --tw-ring-color: rgb(var(--secondary-rgb) / var(--tw-ring-opacity)) !important
+}


### PR DESCRIPTION
Not entirely sure where you overrode it in the light mode, but this is the 'way' to do it for both light and dark.

Should solve https://github.com/DarrianCZE/vamsys-v5-custom-css/issues/1